### PR TITLE
Avoid crashing when sock_mod is undefined

### DIFF
--- a/src/gen_lockstep.erl
+++ b/src/gen_lockstep.erl
@@ -266,8 +266,9 @@ handle_info(_Message, State) ->
 
 terminate(Reason, #state{sock_mod=Mod, sock=Sock, cb_mod=Callback, cb_state=CbState}) ->
     catch Callback:terminate(Reason, CbState),
-    Mod:close(Sock),
-    ok.
+    if is_atom(Mod), Mod =/= undefined, Sock =/= undefined -> Mod:close(Sock)
+     ; true -> ok
+    end.
 
 code_change(_OldVersion, State, _Extra) ->
     {ok, State}.


### PR DESCRIPTION
Failures currently may occur if:
- sock_mod is never initialized in init, only in connections that have
  been established successfilly
- it is called in plenty of places, usually caught or validated, except in
  terminate/2.
- in terminate/2, there is no check to know whether 'sock_mod' is
  defined or not.

The result is that a lockstep process that terminates without ever
managing to get a successful connection (say it crashed) will therefore
loudly fail for no good reason.

This patch makes the `terminate/2` function validate the presence of
`Mod` to know whether it's been set or not, and whether the socket
itself exists before calling `Mod:close/1` on it.
