### PR TITLE
add reconnect logic

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,9 @@
         {rebar_vsn_plugin, ".*",
          {git, "https://github.com/erlware/rebar_vsn_plugin.git", {branch, "master"}}},
         {mochiweb, "",
-         {git, "git@git.herokai.com:mochiweb.git", "3d331c66cca944dbf007cb024cfd109289f59d9b"}}
+         {git, "git@git.herokai.com:mochiweb.git", "3d331c66cca944dbf007cb024cfd109289f59d9b"}},
+        {meck,".*",
+         {git,"git@git.herokai.com:meck.git", "2eb19524a0cf33a0fc67fed766679c93d363ceee"}}
        ]}.
 
 %% Rebar Plugins ==============================================================

--- a/src/gen_lockstep.erl
+++ b/src/gen_lockstep.erl
@@ -277,7 +277,7 @@ handle_info(timeout, #state{sock_mod=OldSockMod, sock=OldSock, url=DefaultUrl, s
                     catch Callback:terminate(Err, CbState1),
                     {stop, Err, anonymize(State)}
             end;
-        {error, reconnect_failed = Err} ->
+        {error, too_many_reconnect_attempts = Err} ->
             catch Callback:terminate(Err, CbState),
             {stop, Err, anonymize(State)};
         Err ->
@@ -323,7 +323,7 @@ connect(Uri) ->
     connect(Uri, ?RECONNECT_ATTEMPTS).
 
 connect(_Uri, 0) ->
-    {error, reconnect};
+    {error, too_many_reconnect_attempts};
 connect({Proto, _Pass, Host, Port, _Path, _}=Uri, Attempts) ->
     Opts = [binary, {packet, http_bin}, {packet_size, 1024 * 1024}, {recbuf, 1024 * 1024}, {active, once}],
     case gen_tcp:connect(Host, Port, Opts, ?RECONNECT_TIMEOUT) of


### PR DESCRIPTION
currently, unless the callback implements some reconnection logic, if we
ever fail to connect to a remote port for some reason, we just give and
never retry, then get killed by the lockstep_killer sometime later,
often after how out of sync we are has caused some problems.  this patch
adds some reconnection attempts and then actively kills the gen_server
if it cannot reconnect.  the idea here is to fail safer, or at least
more quickly.  I tried to add a test, but without pretty low-level
control of the socket, it looks hard to add one locally.