### PR TITLE
Add client identifier

### DIFF
--- a/src/gen_lockstep.erl
+++ b/src/gen_lockstep.erl
@@ -402,6 +402,7 @@ req(Pass, Host, Path, QS) ->
     iolist_to_binary([
         <<"GET ">>, Path, QS, <<" HTTP/1.1\r\n">>,
         authorization(Pass),
+        client_id(),
         <<"Host: ">>, Host ,<<"\r\n\r\n">>
     ]).
 
@@ -418,6 +419,9 @@ authorization(UserPass) ->
             [User, Pass] -> base64:encode(User ++ ":" ++ Pass)
         end,
     [<<"Authorization: Basic ">>, Auth, <<"\r\n">>].
+
+client_id() ->
+  [<<"X-Client-ID: ">>, atom_to_list(node()), <<"\r\n">>].
 
 send_req(IsRedirect, Sock, Mod, {_Proto, Pass, Host, _Port, Path, QS}, Callback, CbState) ->
     try Callback:handle_event(connect, CbState) of

--- a/src/gen_lockstep.erl
+++ b/src/gen_lockstep.erl
@@ -421,7 +421,11 @@ authorization(UserPass) ->
     [<<"Authorization: Basic ">>, Auth, <<"\r\n">>].
 
 client_id() ->
-  [<<"X-Client-ID: ">>, atom_to_list(node()), <<"\r\n">>].
+    case os:getenv("INSTANCE_NAME") of
+        false -> [];
+        InstanceName ->
+            [<<"X-Client-ID: ">>, InstanceName, <<"\r\n">>]
+    end.
 
 send_req(IsRedirect, Sock, Mod, {_Proto, Pass, Host, _Port, Path, QS}, Callback, CbState) ->
     try Callback:handle_event(connect, CbState) of

--- a/test/lockstep_gen_SUITE.erl
+++ b/test/lockstep_gen_SUITE.erl
@@ -307,7 +307,6 @@ connect_content_length_loop(Req, Tid) ->
     Path = Req:get(path),
     Query = Req:parse_qs(),
     ClientID = Req:get_header_value("X-Client-ID"),
-    %% TODO
     ets:insert(Tid, {get, [{method, Method},
                            {path, Path},
                            {qs, Query},


### PR DESCRIPTION
This adds an `X-Client-ID` header to connection requests which will allow us to correlate streamed updates to individual nodes.