### PR TITLE
Add error log in content_len_parser:parse_msg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REBAR := $(shell which rebar)
+REBAR := $(shell which rebar3)
 
 all: compile
 

--- a/src/gen_lockstep.erl
+++ b/src/gen_lockstep.erl
@@ -243,6 +243,7 @@ handle_info({Proto, Sock, Data}, #state{cb_mod=Callback,
             Mod:close(Sock),
             disconnect(State);
         {Err, CbState1} ->
+            error_logger:info_report([{parse_error, Err}, {content_len, ContentLen}, {data, Data}]),
             catch Callback:terminate(Err, CbState1),
             {stop, Err, anonymize(State)}
     end;

--- a/src/gen_lockstep.erl
+++ b/src/gen_lockstep.erl
@@ -224,6 +224,7 @@ handle_info({Proto, Sock, Data}, #state{cb_mod=Callback,
             Mod:close(Sock),
             disconnect(State);
         {Err, CbState1} ->
+            error_logger:info_report([{chunked_parse_error, Err}, {data, Data}]),
             catch Callback:terminate(Err, CbState1),
             {stop, Err, anonymize(State)}
     end;


### PR DESCRIPTION
Also, move to rebar3 in Makefile to fetch dependencies properly.

```
===> Verifying dependencies...
===> Compiling lockstep
===> Running Common Test suites...
%%% lockstep_gen_SUITE: .......
%%% lockstep_parse_SUITE: .......
All 14 tests passed.
```

/cc @ypaq 