### PR TITLE
Fix end of body/stream callback state passing

### DIFF
--- a/src/chunked_parser.erl
+++ b/src/chunked_parser.erl
@@ -30,7 +30,7 @@ parse_msgs(<<>>, _Callback, CbState) ->
 parse_msgs(Data, Callback, CbState) ->
     case read_size(Data) of
         {ok, 0, _Rest} ->
-            {ok, end_of_stream};
+            {ok, end_of_stream, CbState};
         {ok, Size, Rest} ->
             case read_chunk(Rest, Size) of
                 {ok, <<"\r\n">>, Rest1} ->

--- a/src/content_len_parser.erl
+++ b/src/content_len_parser.erl
@@ -24,8 +24,8 @@
 -module(content_len_parser).
 -export([parse_msgs/4]).
 
-parse_msgs(<<>>, 0, _Callback, _CbState) ->
-    {ok, end_of_body};
+parse_msgs(<<>>, 0, _Callback, CbState) ->
+    {ok, end_of_body, CbState};
 
 parse_msgs(<<>>, ContentLen, _Callback, CbState) ->
     {ok, CbState, ContentLen, <<>>};

--- a/src/gen_lockstep.erl
+++ b/src/gen_lockstep.erl
@@ -222,9 +222,9 @@ handle_info({Proto, Sock, Data}, #state{cb_mod=Callback,
         {ok, CbState1, Rest} ->
             setopts(Mod, Sock, [{active, once}]),
             {noreply, State#state{cb_state=CbState1, buffer=Rest}, ?IDLE_TIMEOUT};
-        {ok, end_of_stream} ->
+        {ok, end_of_stream, CbState1} ->
             Mod:close(Sock),
-            disconnect(State);
+            disconnect(State#state{cb_state = CbState1});
         {Err, CbState1} ->
             error_logger:info_report([{chunked_parse_error, Err}, {data, Data}]),
             catch Callback:terminate(Err, CbState1),
@@ -242,9 +242,9 @@ handle_info({Proto, Sock, Data}, #state{cb_mod=Callback,
         {ok, CbState1, ContentLen1, Rest} ->
             setopts(Mod, Sock, [{active, once}]),
             {noreply, State#state{cb_state=CbState1, content_length=ContentLen1, buffer=Rest}, ?IDLE_TIMEOUT};
-        {ok, end_of_body} ->
+        {ok, end_of_body, CbState1} ->
             Mod:close(Sock),
-            disconnect(State);
+            disconnect(State#state{cb_state = CbState1});
         {Err, CbState1} ->
             error_logger:info_report([{parse_error, Err}, {content_len, ContentLen}, {data, Data}]),
             catch Callback:terminate(Err, CbState1),

--- a/src/gen_lockstep.erl
+++ b/src/gen_lockstep.erl
@@ -189,6 +189,8 @@ handle_info({Proto, Sock, {http_header, _, Key, _, Val}}, #state{sock_mod=Mod}=S
     case [Key, Val] of
         [<<"Instance-Name">>, InstanceName] ->
             notify_callback({instance_name, InstanceName}, State);
+        [<<"X-Amz-Meta-Count">>, Count] ->
+            notify_callback({meta_count, list_to_integer(binary_to_list(Count))}, State);
         ['Transfer-Encoding', <<"chunked">>] ->
             {noreply, State#state{encoding=chunked}};
         ['Content-Length', ContentLength] ->

--- a/test/lockstep_gen_callback.erl
+++ b/test/lockstep_gen_callback.erl
@@ -43,6 +43,12 @@ handle_event({client_error, 401}, #hstate{tid=Tid}=HandlerState) ->
     [{correct_url, CorrectURL}] = ets:lookup(Tid, correct_url),
     true = ets:insert(Tid, {changed_url, true}),
     {connect_url, CorrectURL, HandlerState};
+handle_event({instance_name, InstanceName}, #hstate{tid=Tid}=HandlerState) ->
+    true = ets:insert(Tid, {instance_name, InstanceName}),
+    {noreply, HandlerState};
+handle_event({meta_count, Count}, #hstate{tid=Tid}=HandlerState) ->
+    true = ets:insert(Tid, {meta_count, Count}),
+    {noreply, HandlerState};
 handle_event(_Event, HandlerState) ->
     {noreply, HandlerState}.
 


### PR DESCRIPTION
Updates made to the callback state before the end of body or stream depending on the parser were dropped. Now we retain these updates.