### PR TITLE
Upgrade meck to 0.8.12

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
     {test, [
         {deps, [
             {meck,".*",
-             {git,"ssh://git@git.herokai.com:2222/meck.git", "2eb19524a0cf33a0fc67fed766679c93d363ceee"}}
+             {git,"ssh://git@git.herokai.com:2222/meck.git", {tag, "0.8.12"}}}
         ]}
     ]}
 ]}.


### PR DESCRIPTION
The version of meck specified in the rebar config depends on a
deprecated function in erlang 21 and fails to build:

```
===> Compiling meck
===> Compiling _build/test/lib/meck/src/meck_code_gen.erl failed
_build/test/lib/meck/src/meck_code_gen.erl:182: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
```

This updates to the latest tagged version of meck.