### PR TITLE
Enable CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: erlang
+otp_release:
+  - 20.1
+  - 19.3
+script:
+  - rebar3 eunit && rebar3 ct
+notifications:
+  email: false

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 {deps, [
-        {mochiweb, "",
-         {git, "ssh://git@git.herokai.com:2222/mochiweb.git", "3d331c66cca944dbf007cb024cfd109289f59d9b"}},
+        mochiweb,
         idna,
         certifi,
         ssl_verify_fun
@@ -9,8 +8,7 @@
 {profiles, [
     {test, [
         {deps, [
-            {meck,".*",
-             {git,"ssh://git@git.herokai.com:2222/meck.git", {tag, "0.8.12"}}}
+            meck
         ]}
     ]}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,22 +1,16 @@
 {"1.1.0",
-[{<<"certifi">>,{pkg,<<"certifi">>,<<"0.4.0">>},0},
- {<<"idna">>,{pkg,<<"idna">>,<<"2.0.0">>},0},
- {<<"meck">>,
-  {git,"ssh://git@git.herokai.com:2222/meck.git",
-       {ref,"2eb19524a0cf33a0fc67fed766679c93d363ceee"}},
-  0},
- {<<"mochiweb">>,
-  {git,"ssh://git@git.herokai.com:2222/mochiweb.git",
-       {ref,"3d331c66cca944dbf007cb024cfd109289f59d9b"}},
-  0},
- {<<"rebar_vsn_plugin">>,
-  {git,"https://github.com/erlware/rebar_vsn_plugin.git",
-       {ref,"fd40c960c7912193631d948fe962e1162a8d1334"}},
-  0},
- {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.0">>},0}]}.
+[{<<"certifi">>,{pkg,<<"certifi">>,<<"2.4.2">>},0},
+ {<<"idna">>,{pkg,<<"idna">>,<<"6.0.0">>},0},
+ {<<"mochiweb">>,{pkg,<<"mochiweb">>,<<"2.18.0">>},0},
+ {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},1},
+ {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.4">>},0},
+ {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.4.1">>},1}]}.
 [
 {pkg_hash,[
- {<<"certifi">>, <<"A7966EFB868B179023618D29A407548F70C52466BF1849B9E8EBD0E34B7EA11F">>},
- {<<"idna">>, <<"13DC2C407F16FF24648AF98F529CEC5B957E2FAFA849DF11D52D82E11529C4C1">>},
- {<<"ssl_verify_fun">>, <<"EDEE20847C42E379BF91261DB474FFBE373F8ACB56E9079ACB6038D4E0BF414F">>}]}
+ {<<"certifi">>, <<"75424FF0F3BAACCFD34B1214184B6EF616D89E420B258BB0A5EA7D7BC628F7F0">>},
+ {<<"idna">>, <<"689C46CBCDF3524C44D5F3DDE8001F364CD7608A99556D8FBD8239A5798D4C10">>},
+ {<<"mochiweb">>, <<"EB55F1DB3E6E960FAC4E6DB4E2DB9EC3602CC9F30B86CD1481D56545C3145D2E">>},
+ {<<"parse_trans">>, <<"09765507A3C7590A784615CFD421D101AEC25098D50B89D7AA1D66646BC571C1">>},
+ {<<"ssl_verify_fun">>, <<"F0EAFFF810D2041E93F915EF59899C923F4568F4585904D010387ED74988E77B">>},
+ {<<"unicode_util_compat">>, <<"D869E4C68901DD9531385BB0C8C40444EBF624E60B6962D95952775CAC5E90CD">>}]}
 ].

--- a/test/lockstep_gen_SUITE.erl
+++ b/test/lockstep_gen_SUITE.erl
@@ -220,7 +220,7 @@ reconnect(Config) ->
     Config.
 
 timeout(Config) ->
-    % Check timeout
+    % Check idle timeout
     register(timeout, self()),
     Tid = ?config(tid, Config),
     {ok, Pid} = gen_lockstep:start_link(lockstep_gen_callback,
@@ -238,7 +238,7 @@ timeout(Config) ->
         new_connection ->
             [{count, 2}] = ets:lookup(Tid, count),
             loop ! close
-    after 100 ->
+    after 1000 ->
             throw(timeout)
     end,
     bye = gen_lockstep:call(Pid, stop_test, 1000),


### PR DESCRIPTION
lockstep previously depended on maintainers or contributors to run tests
locally to validate changes.

This enables Travis CI to test with Erlang OTP releases 19.3 and 20.1.
It also:

  * Replaces dependency references from internal-only Git sources to
    public dependencies.
  * Fixes a bug in one of the tests which prevented CI from passing