### PR TITLE
Bug fixes: case handling & dialyzer issue

### DIFF
--- a/src/chunked_parser.erl
+++ b/src/chunked_parser.erl
@@ -59,9 +59,7 @@ parse_msgs(Data, Callback, CbState) ->
                     {ok, CbState, Data};
                 {error, malformed_chunk} ->
                     error_logger:info_report([{error, malformed_chunk}, {size, Size}, {data, Data}]),
-                    {error, malformed_chunk};
-                Err ->
-                    {Err, CbState}
+                    {error, malformed_chunk}
             end;
         eof ->
             {ok, CbState, Data};
@@ -76,7 +74,7 @@ read_size(Data) ->
                 {ok, [Size], []} ->
                     {ok, Size, Rest};
                 _ ->
-                    {error, {poorly_formatted_size, Line}} 
+                    {error, {poorly_formatted_size, Line}}
             end;
         Err ->
             Err

--- a/src/gen_lockstep.erl
+++ b/src/gen_lockstep.erl
@@ -219,12 +219,12 @@ handle_info({Proto, Sock, Data}, #state{cb_mod=Callback,
                                         buffer=Buffer}=State)
   when Proto == tcp; Proto == ssl ->
     case chunked_parser:parse_msgs(<<Buffer/binary, Data/binary>>, Callback, CbState0) of
-        {ok, CbState1, Rest} ->
-            setopts(Mod, Sock, [{active, once}]),
-            {noreply, State#state{cb_state=CbState1, buffer=Rest}, ?IDLE_TIMEOUT};
         {ok, end_of_stream, CbState1} ->
             Mod:close(Sock),
             disconnect(State#state{cb_state = CbState1});
+        {ok, CbState1, Rest} ->
+            setopts(Mod, Sock, [{active, once}]),
+            {noreply, State#state{cb_state=CbState1, buffer=Rest}, ?IDLE_TIMEOUT};
         {Err, CbState1} ->
             error_logger:info_report([{chunked_parse_error, Err}, {data, Data}]),
             catch Callback:terminate(Err, CbState1),


### PR DESCRIPTION
* Fix ghosted case handling: the `end_of_stream` clause was completely covered by the previous clause.

* Fix dialyzer issue: 
   ```
   src/chunked_parser.erl
   63: The variable Err can never match since previous clauses completely covered the type 'eof' | {'error','malformed_chunk'} | {'ok',binary(),binary()}
   ```