### PR TITLE
Improve test cycle speed

### DIFF
--- a/src/gen_lockstep.erl
+++ b/src/gen_lockstep.erl
@@ -317,8 +317,8 @@ handle_close_or_disconnect(Event, State)
     end.
 
 %% attempt to reconnect every 5s for 2 minutes
--define(RECONNECT_TIMEOUT, timer:seconds(5)).
--define(RECONNECT_ATTEMPTS, 24).
+-define(RECONNECT_TIMEOUT, application:get_env(lockstep, reconnect_timeout, timer:seconds(5))).
+-define(RECONNECT_ATTEMPTS, application:get_env(lockstep, reconnect_attempts, 24)).
 
 connect(Url) when is_list(Url) ->
     Uri = parse_uri(Url),

--- a/test/lockstep_gen_SUITE.erl
+++ b/test/lockstep_gen_SUITE.erl
@@ -24,6 +24,8 @@ all() ->
 
 init_per_suite(Config) ->
     application:load(lockstep),
+    application:set_env(lockstep, reconnect_timeout, timer:seconds(5)),
+    application:set_env(lockstep, reconnect_attempts, 2),
     application:start(meck),
     Config.
 


### PR DESCRIPTION
Changed the hard coded reconnect parameters to application default parameters which are overridden during testing.